### PR TITLE
Fix tradeskill scanning when TSM replaces Blizzard UI

### DIFF
--- a/Events.lua
+++ b/Events.lua
@@ -962,10 +962,18 @@ local function scanTradeskills()
 
     local tradeskillCooldowns = {}
 
-    local tradeskillTitle = TradeSkillFrameTitleText:GetText()
-    if tradeskillTitle then
-        prof = Tradeskills:GetTradeskillIDFromLocale(tradeskillTitle)
+-- #### Caused a LUA error if TSM addon used because TradeSkillFrameTitleText not available
+    -- local tradeskillTitle = TradeSkillFrameTitleText:GetText()
+    -- if tradeskillTitle then
+    --     prof = Tradeskills:GetTradeskillIDFromLocale(tradeskillTitle)
+    -- end
+-- #### Replaced with GetTradeSkillLine() API call which returns the tradeskillName by default
+
+    local tradeskillTitle = GetTradeSkillLine()
+    if not tradeskillTitle then
+        return
     end
+    local prof = Tradeskills:GetTradeskillIDFromLocale(tradeskillTitle)
 
     if type(prof) == "number" then
         addon.LogDebugMessage("tradeskills", string.format("function [scanTradeskills] prof = %s", prof))


### PR DESCRIPTION
This change replaces TradeSkillFrameTitleText:GetText() with GetTradeSkillLine() when determining the active profession.

TradeSkillFrameTitleText is not available when TradeSkillMaster replaces the professions UI, causing a Lua error during tradeskill scanning.

GetTradeSkillLine() API returns the active tradeskill name directly and works with both the default UI and TradeSkillMaster.

Behavior is otherwise unchanged, as the same localized profession name is used downstream.